### PR TITLE
Escape dollar signs with backslash

### DIFF
--- a/simple-mathjax.php
+++ b/simple-mathjax.php
@@ -14,7 +14,7 @@
 add_action('wp_head','configure_mathjax',1);
 function configure_mathjax() {
   $custom_config = wp_kses( get_option('custom_mathjax_config'), array() );
-  $config = $custom_config ? $custom_config : "MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\\\(','\\\\)']]}});\n";
+  $config = $custom_config ? $custom_config : "MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\\\(','\\\\)']], processEscapes: true}});\n";
   echo "\n<script type='text/x-mathjax-config'>\n" . $config . "</script>\n";
 }
 


### PR DESCRIPTION
Set the processEscapes flag to true so that dollar signs can be added to the blog post by escaping with backslash.

This seems like something that most everyone is going to want. Otherwise, it is very difficult to add $ to your post.